### PR TITLE
Sass Indentation

### DIFF
--- a/indent/sass.vim
+++ b/indent/sass.vim
@@ -17,7 +17,8 @@ if exists("*GetSassIndent")
   finish
 endif
 
-let s:property = '^\s*:\|^\s*[[:alnum:]-]\+\%(:\|\s*=\)'
+let s:property = '^\s*:\|^\s*[[:alnum:]#{}-]\+\%(:\|\s*=\)'
+let s:extend = '^\s*\%(@include\|@extend\|+\)'
 
 function! GetSassIndent()
   let lnum = prevnonblank(v:lnum-1)
@@ -27,7 +28,7 @@ function! GetSassIndent()
   let line = substitute(line,'^\s\+','','')
   let indent = indent(lnum)
   let cindent = indent(v:lnum)
-  if line !~ s:property && cline =~ s:property
+  if line !~ s:property && line !~ s:extend && cline =~ s:property
     return indent + &sw
   "elseif line =~ s:property && cline !~ s:property
     "return indent - &sw


### PR DESCRIPTION
I have had a problem with indentation in Sass files, where properties are indented incorrectly when they follow a mixin.

For example:

```
table
  +alternating-rows
  border-collapse: collapse
```

When typing the colon for the border-collapse property, the line would be automatically indented another level deep, which is really annoying. This happens regardless of whether you use the + syntax or the @mixin syntax for the mixin.

I have provided a patch that fixes this problem.
