### PR TITLE
Indentation of SCSS

### DIFF
--- a/indent/scss.vim
+++ b/indent/scss.vim
@@ -10,7 +10,6 @@ let b:did_indent = 1
 
 setlocal indentexpr=GetSCSSIndent()
 setlocal indentkeys=0{,0},!^F,o,O
-setlocal nosmartindent
 
 if exists("*GetSCSSIndent")
   finish


### PR DESCRIPTION
Hi
The indentation of SCSS is screwed up because it uses the CSS indent which do not have nesting. Somebody else asked the question on Stackoverflow. http://stackoverflow.com/questions/4829244/how-do-i-define-indents-in-vim-based-on-curly-braces

I have implementet the answer and it works like a charm. So all credit goes to answerer Al 
