### PR TITLE
Add Rails' asset-pipeline SASS helper methods

### DIFF
--- a/syntax/sass.vim
+++ b/syntax/sass.vim
@@ -33,6 +33,8 @@ syn match sassFunction "\<\%(alpha\|opacity\|rgba\|opacify\|fade-in\|transparent
 syn match sassFunction "\<\%(unquote\|quote\)\>(\@=" contained
 syn match sassFunction "\<\%(percentage\|round\|ceil\|floor\|abs\)\>(\@=" contained
 syn match sassFunction "\<\%(type-of\|unit\|unitless\|comparable\)\>(\@=" contained
+syn match sassFunction "\<\%(\%(asset\|image\|font\|video\|audio\|javascript\|stylesheet\)-\%(url\|path\)\)\>(\@=" contained
+syn match sassFunction "\<\asset-data-url\>(\@=" contained
 
 syn region sassInterpolation matchgroup=sassInterpolationDelimiter start="#{" end="}" contains=@sassCssAttributes,sassVariable,sassFunction containedin=cssStringQ,cssStringQQ,sassProperty
 


### PR DESCRIPTION
Hi, just a tiny patch to add sass syntax highlighting support for Rails 3.1 helper methods like image-url("foo.png").  Any thoughts?
