### PR TITLE
Add interpolation for pseudo elements

### DIFF
--- a/syntax/sass.vim
+++ b/syntax/sass.vim
@@ -34,7 +34,7 @@ syn match sassFunction "\<\%(unquote\|quote\)\>(\@=" contained
 syn match sassFunction "\<\%(percentage\|round\|ceil\|floor\|abs\)\>(\@=" contained
 syn match sassFunction "\<\%(type-of\|unit\|unitless\|comparable\)\>(\@=" contained
 
-syn region sassInterpolation matchgroup=sassInterpolationDelimiter start="#{" end="}" contains=@sassCssAttributes,sassVariable,sassFunction containedin=cssStringQ,cssStringQQ,sassProperty
+syn region sassInterpolation matchgroup=sassInterpolationDelimiter start="#{" end="}" contains=@sassCssAttributes,sassVariable,sassFunction containedin=cssStringQ,cssStringQQ,cssPseudoClass,sassProperty
 
 syn match sassMixinName "[[:alnum:]_-]\+" contained nextgroup=sassCssAttribute
 syn match sassMixin  "^="               nextgroup=sassMixinName skipwhite


### PR DESCRIPTION
Example:

``` sass
@for $i from 1 through 7
  li.menu:nth-child(#{$i})
    +animation-delay(0.44s + (0.037s * $i))
```

Should now highlight SASS interpolation inside cssPseudoClass
