### PR TITLE
override softtabstop

### DIFF
--- a/indent/haml.vim
+++ b/indent/haml.vim
@@ -10,7 +10,7 @@ runtime! indent/ruby.vim
 unlet! b:did_indent
 let b:did_indent = 1
 
-setlocal autoindent sw=2 et
+setlocal autoindent sw=2 sts=2 et
 setlocal indentexpr=GetHamlIndent()
 setlocal indentkeys=o,O,*<Return>,},],0),!^F,=end,=else,=elsif,=rescue,=ensure,=when
 


### PR DESCRIPTION
Override global softtabstop value by setting sts=2 for haml files
