### PR TITLE
Add initial support for `haml-js`

### DIFF
--- a/ftdetect/haml.vim
+++ b/ftdetect/haml.vim
@@ -1,3 +1,3 @@
-autocmd BufNewFile,BufRead *.haml,*.hamlbars setf haml
+autocmd BufNewFile,BufRead *.haml,*.hamlbars,*.hamljs setf haml
 autocmd BufNewFile,BufRead *.sass setf sass
 autocmd BufNewFile,BufRead *.scss setf scss

--- a/indent/haml.vim
+++ b/indent/haml.vim
@@ -37,7 +37,16 @@ function! GetHamlIndent()
   let line = substitute(line,'^\s\+','','')
   let indent = indent(lnum)
   let cindent = indent(v:lnum)
-  if cline =~# '\v^-\s*%(elsif|else|when)>'
+
+  if b:haml_variant == 'hamljs'
+    let outdent_atoms = '}'
+    let haml_statement = '^'.s:tag.'[&!]\=[=~-]\s*}\?\s*\%(\%(if\|else\|else if\|for\)\>\)'
+  else
+    let outdent_atoms = 'elsif\|else\|when'
+    let haml_statement = '^'.s:tag.'[&!]\=[=~-]\s*\%(\%(if\|else\|elsif\|unless\|case\|when\|while\|until\|for\|begin\|module\|class\|def\)\>\%(.*\<end\>\)\@!\|.*do\%(\s*|[^|]*|\)\=\s*$\)'
+  endif
+
+  if cline =~# '^-\s*\('.outdent_atoms.'\)'
     let indent = cindent < indent ? cindent : indent - &sw
   endif
   let increase = indent + &sw
@@ -53,7 +62,7 @@ function! GetHamlIndent()
     return increase
   elseif group == 'hamlFilter'
     return increase
-  elseif line =~ '^'.s:tag.'[&!]\=[=~-]\s*\%(\%(if\|else\|elsif\|unless\|case\|when\|while\|until\|for\|begin\|module\|class\|def\)\>\%(.*\<end\>\)\@!\|.*do\%(\s*|[^|]*|\)\=\s*$\)'
+  elseif line =~ haml_statement
     return increase
   elseif line =~ '^'.s:tag.'[&!]\=[=~-].*,\s*$'
     return increase

--- a/syntax/haml.vim
+++ b/syntax/haml.vim
@@ -11,18 +11,16 @@ endif
 if !exists("main_syntax")
   let main_syntax = 'haml'
 endif
-let b:ruby_no_expensive = 1
+
+if !exists("b:haml_variant")
+  let b:haml_variant = expand("%:e")
+endif
 
 runtime! syntax/html.vim
 unlet! b:current_syntax
 silent! syn include @hamlSassTop syntax/sass.vim
-unlet! b:current_syntax
-syn include @hamlRubyTop syntax/ruby.vim
 
 syn case match
-
-syn region  rubyCurlyBlock   start="{" end="}" contains=@hamlRubyTop contained
-syn cluster hamlRubyTop add=rubyCurlyBlock
 
 syn cluster hamlComponent    contains=hamlAttributes,hamlAttributesHash,hamlClassChar,hamlIdChar,hamlObject,hamlDespacer,hamlSelfCloser,hamlRuby,hamlPlainChar,hamlInterpolatable
 syn cluster hamlEmbeddedRuby contains=hamlAttributesHash,hamlObject,hamlRuby,hamlRubyFilter
@@ -32,8 +30,8 @@ syn match   hamlBegin "^\s*\%([<>]\|&[^=~ ]\)\@!" nextgroup=hamlTag,hamlClassCha
 
 syn match   hamlTag        "%\w\+\%(:\w\+\)\=" contained contains=htmlTagName,htmlSpecialTagName nextgroup=@hamlComponent
 syn region  hamlAttributes     matchgroup=hamlAttributesDelimiter start="(" end=")" contained contains=htmlArg,hamlAttributeString,hamlAttributeVariable,htmlEvent,htmlCssDefinition nextgroup=@hamlComponent
-syn region  hamlAttributesHash matchgroup=hamlAttributesDelimiter start="{" end="}" contained contains=@hamlRubyTop nextgroup=@hamlComponent
-syn region  hamlObject         matchgroup=hamlObjectDelimiter     start="\[" end="\]" contained contains=@hamlRubyTop nextgroup=@hamlComponent
+syn region  hamlAttributesHash matchgroup=hamlAttributesDelimiter start="{" end="}" contained contains=@hamlBaseLanguage nextgroup=@hamlComponent
+syn region  hamlObject         matchgroup=hamlObjectDelimiter     start="\[" end="\]" contained contains=@hamlBaseLanguage nextgroup=@hamlComponent
 syn match   hamlDespacer "[<>]" contained nextgroup=hamlDespacer,hamlSelfCloser,hamlRuby,hamlPlainChar,hamlInterpolatable
 syn match   hamlSelfCloser "/" contained
 syn match   hamlClassChar "\." contained nextgroup=hamlClass
@@ -42,27 +40,26 @@ syn match   hamlClass "\%(\w\|-\)\+" contained nextgroup=@hamlComponent
 syn match   hamlId    "\%(\w\|-\)\+" contained nextgroup=@hamlComponent
 syn region  hamlDocType start="^\s*!!!" end="$"
 
-syn region  hamlRuby   matchgroup=hamlRubyOutputChar start="[!&]\==\|\~" skip=",\s*$" end="$" contained contains=@hamlRubyTop keepend
-syn region  hamlRuby   matchgroup=hamlRubyChar       start="-"           skip=",\s*$" end="$" contained contains=@hamlRubyTop keepend
+syn region  hamlRuby   matchgroup=hamlRubyOutputChar start="[!&]\==\|\~" skip=",\s*$" end="$" contained contains=@hamlBaseLanguage keepend
+syn region  hamlRuby   matchgroup=hamlRubyChar       start="-"           skip=",\s*$" end="$" contained contains=@hamlBaseLanguage keepend
 syn match   hamlPlainChar "\\" contained
 syn region hamlInterpolatable matchgroup=hamlInterpolatableChar start="!\===\|!=\@!" end="$" keepend contained contains=hamlInterpolation,hamlInterpolationEscape,@hamlHtmlTop
 syn region hamlInterpolatable matchgroup=hamlInterpolatableChar start="&==\|&=\@!"   end="$" keepend contained contains=hamlInterpolation,hamlInterpolationEscape
-syn region hamlInterpolation matchgroup=hamlInterpolationDelimiter start="#{" end="}" contains=@hamlRubyTop containedin=javascriptStringS,javascriptStringD
+syn region hamlInterpolation matchgroup=hamlInterpolationDelimiter start="#{" end="}" contains=@hamlBaseLanguage containedin=javascriptStringS,javascriptStringD
 syn match  hamlInterpolationEscape "\\\@<!\%(\\\\\)*\\\%(\\\ze#{\|#\ze{\)"
-syn region hamlErbInterpolation matchgroup=hamlInterpolationDelimiter start="<%[=-]\=" end="-\=%>" contained contains=@hamlRubyTop
+syn region hamlErbInterpolation matchgroup=hamlInterpolationDelimiter start="<%[=-]\=" end="-\=%>" contained contains=@hamlBaseLanguage
 
 syn region  hamlAttributeString start=+\%(=\s*\)\@<='+ skip=+\%(\\\\\)*\\'+ end=+'+ contains=hamlInterpolation,hamlInterpolationEscape
 syn region  hamlAttributeString start=+\%(=\s*\)\@<="+ skip=+\%(\\\\\)*\\"+ end=+"+ contains=hamlInterpolation,hamlInterpolationEscape
 syn match   hamlAttributeVariable "\%(=\s*\)\@<=\%(@@\=\|\$\)\=\w\+" contained
 
-syn match   hamlHelper  "\<action_view?\|\<block_is_haml?\|\<is_haml?\|\.\@<!\<flatten" contained containedin=@hamlEmbeddedRuby,@hamlRubyTop
-syn keyword hamlHelper   capture_haml escape_once find_and_preserve haml_concat haml_indent haml_tag html_attrs html_esape init_haml_helpers list_of non_haml precede preserve succeed surround tab_down tab_up page_class contained containedin=@hamlEmbeddedRuby,@hamlRubyTop
+syn match   hamlHelper  "\<action_view?\|\<block_is_haml?\|\<is_haml?\|\.\@<!\<flatten" contained containedin=@hamlEmbeddedRuby,@hamlBaseLanguage
+syn keyword hamlHelper   capture_haml escape_once find_and_preserve haml_concat haml_indent haml_tag html_attrs html_esape init_haml_helpers list_of non_haml precede preserve succeed surround tab_down tab_up page_class contained containedin=@hamlEmbeddedRuby,@hamlBaseLanguage
 
 syn cluster hamlHtmlTop contains=@htmlTop,htmlBold,htmlItalic,htmlUnderline
 syn region  hamlPlainFilter      matchgroup=hamlFilter start="^\z(\s*\):\%(plain\|preserve\|redcloth\|textile\|markdown\|maruku\)\s*$" end="^\%(\z1 \| *$\)\@!" contains=@hamlHtmlTop,hamlInterpolation
 syn region  hamlEscapedFilter    matchgroup=hamlFilter start="^\z(\s*\):\%(escaped\|cdata\)\s*$"    end="^\%(\z1 \| *$\)\@!" contains=hamlInterpolation
 syn region  hamlErbFilter        matchgroup=hamlFilter start="^\z(\s*\):erb\s*$"        end="^\%(\z1 \| *$\)\@!" contains=@hamlHtmlTop,hamlErbInterpolation
-syn region  hamlRubyFilter       matchgroup=hamlFilter start="^\z(\s*\):ruby\s*$"       end="^\%(\z1 \| *$\)\@!" contains=@hamlRubyTop
 syn region  hamlJavascriptFilter matchgroup=hamlFilter start="^\z(\s*\):javascript\s*$" end="^\%(\z1 \| *$\)\@!" contains=@htmlJavaScript,hamlInterpolation keepend
 syn region  hamlCSSFilter        matchgroup=hamlFilter start="^\z(\s*\):css\s*$"        end="^\%(\z1 \| *$\)\@!" contains=@htmlCss,hamlInterpolation keepend
 syn region  hamlSassFilter       matchgroup=hamlFilter start="^\z(\s*\):sass\s*$"       end="^\%(\z1 \| *$\)\@!" contains=@hamlSassTop
@@ -74,6 +71,24 @@ syn match   hamlError "\$" contained
 syn region  hamlComment     start="^\z(\s*\)-#" end="^\%(\z1 \| *$\)\@!" contains=rubyTodo
 syn region  hamlHtmlComment start="^\z(\s*\)/"  end="^\%(\z1 \| *$\)\@!" contains=@hamlTop,rubyTodo
 syn match   hamlIEConditional "\%(^\s*/\)\@<=\[if\>[^]]*]" contained containedin=hamlHtmlComment
+
+if b:haml_variant == 'hamljs'
+  syn region hamljsIfStatement matchgroup=hamlFilter start=":if" skip=",\s*$" end="$" contains=@htmlJavaScript keepend
+  syn region hamljsIterator    matchgroup=hamlFilter start=":each\|:for" skip=",\s*$" end="$" contains=@htmlJavaScript keepend
+
+  unlet! b:current_syntax
+  syn cluster hamlBaseLanguage contains=@htmlJavaScript
+else
+  let b:ruby_no_expensive = 1
+
+  unlet! b:current_syntax
+  syn include @hamlRubyTop syntax/ruby.vim
+
+  syn region  rubyCurlyBlock   start="{" end="}" contains=@hamlRubyTop contained
+  syn region  hamlRubyFilter   matchgroup=hamlFilter start="^\z(\s*\):ruby\s*$"       end="^\%(\z1 \| *$\)\@!" contains=@hamlRubyTop
+
+  syn cluster hamlBaseLanguage contains=@hamlRubyTop,rubyCurlyBlock
+endif
 
 hi def link hamlSelfCloser             Special
 hi def link hamlDespacer               Special


### PR DESCRIPTION
This adds support for [haml-js](https://github.com/creationix/haml-js), while trying to change as little as
possible with the existing implementation.

It's a bit rough around the edges -- I didn't (at present) want to rename all of the ruby* syntax names, but will if this is something worth pulling in. Thoughts?