### PR TITLE
Restricting the SCSS comment matching

### DIFF
--- a/syntax/scss.vim
+++ b/syntax/scss.vim
@@ -2,7 +2,7 @@
 " Language:	SCSS
 " Maintainer:	Tim Pope <vimNOSPAM@tpope.org>
 " Filenames:	*.scss
-" Last Change:	2010 Jul 26
+" Last Change:	2012 Jul 12
 
 if exists("b:current_syntax")
   finish
@@ -10,8 +10,8 @@ endif
 
 runtime! syntax/sass.vim
 
-syn match scssComment "//.*" contains=sassTodo,@Spell
-syn region scssComment start="/\*" end="\*/" contains=sassTodo,@Spell
+syn match scssComment "//.*$" contains=sassTodo,@Spell
+syn region scssComment start="^/\*" end="\*/$" contains=sassTodo,@Spell
 
 hi def link scssComment sassComment
 


### PR DESCRIPTION
Hi Tim,

first of all I want to use this opportunity you for awesome plugin work. Without you using Vim would be only half the fun! Thanks for that.

Today I opened up an SCSS file which uses a wildcard import statement like the following:

```
@import "sprites/menu/*.png";
```

Due to a not so restricted comment matching in the SCSS syntax nearly the whole file seemed to be commented out. My first thought was, why do people not delete code but comment it out? After realizing that the entire file was disabled I thought maybe something else is wrong here :-)

This minor change will fix that. I partly tool it from [this syntax definition for SCSS](https://github.com/cakebaker/scss-syntax.vim/blob/master/syntax/scss.vim).

Thanks for your time.

Best regards,
Dirk
