### PR TITLE
Highlight SASS comments a little better

### DIFF
--- a/syntax/sass.vim
+++ b/syntax/sass.vim
@@ -13,7 +13,7 @@ runtime! syntax/css.vim
 syn case ignore
 
 syn cluster sassCssProperties contains=cssFontProp,cssFontDescriptorProp,cssColorProp,cssTextProp,cssBoxProp,cssGeneratedContentProp,cssPagingProp,cssUIProp,cssRenderProp,cssAuralProp,cssTableProp
-syn cluster sassCssAttributes contains=css.*Attr,scssComment,cssValue.*,cssColor,cssURL,sassDefault,cssImportant,cssError,cssStringQ,cssStringQQ,cssFunction,cssUnicodeEscape,cssRenderProp
+syn cluster sassCssAttributes contains=css.*Attr,sassEndOfLineComment,cssComment,cssValue.*,cssColor,cssURL,sassDefault,cssImportant,cssError,cssStringQ,cssStringQQ,cssFunction,cssUnicodeEscape,cssRenderProp
 
 syn region sassDefinition matchgroup=cssBraces start="{" end="}" contains=TOP
 
@@ -66,7 +66,9 @@ syn keyword sassFor from to through in contained
 syn keyword sassTodo        FIXME NOTE TODO OPTIMIZE XXX contained
 syn region  sassComment     start="^\z(\s*\)//"  end="^\%(\z1 \)\@!" contains=sassTodo,@Spell
 syn region  sassCssComment  start="^\z(\s*\)/\*" end="^\%(\z1 \)\@!" contains=sassTodo,@Spell
+syn match   sassEndOfLineComment "//.*" contains=sassComment,sassTodo,@Spell
 
+hi def link sassEndOfLineComment        sassComment
 hi def link sassCssComment              sassComment
 hi def link sassComment                 Comment
 hi def link sassDefault                 cssImportant


### PR DESCRIPTION
I like to put comments on the end of lines of SASS. // like this

But vim-haml doesn't highlight them.

I took a crack at fixing it. I don't know Vim syntax rules very well, but I think I nailed it.

-Greg
