### PR TITLE
Use shiftwidth() function instead of &sw

### DIFF
--- a/indent/haml.vim
+++ b/indent/haml.vim
@@ -38,9 +38,9 @@ function! GetHamlIndent()
   let indent = indent(lnum)
   let cindent = indent(v:lnum)
   if cline =~# '\v^-\s*%(elsif|else|when)>'
-    let indent = cindent < indent ? cindent : indent - &sw
+    let indent = cindent < indent ? cindent : indent - shiftwidth()
   endif
-  let increase = indent + &sw
+  let increase = indent + shiftwidth()
   if indent == indent(lnum)
     let indent = cindent <= indent ? -1 : increase
   endif

--- a/indent/haml.vim
+++ b/indent/haml.vim
@@ -26,6 +26,18 @@ if !exists('g:haml_self_closing_tags')
   let g:haml_self_closing_tags = 'base|link|meta|br|hr|img|input'
 endif
 
+" The shiftwidth() exists since patch 7.3.694
+" Don't require it to exist.
+if exists('*shiftwidth')
+  function s:sw() abort
+    return shiftwidth()
+  endfunction
+else
+  function s:sw() abort
+    return &shiftwidth
+  endfunction
+endif
+
 function! GetHamlIndent()
   let lnum = prevnonblank(v:lnum-1)
   if lnum == 0
@@ -38,9 +50,9 @@ function! GetHamlIndent()
   let indent = indent(lnum)
   let cindent = indent(v:lnum)
   if cline =~# '\v^-\s*%(elsif|else|when)>'
-    let indent = cindent < indent ? cindent : indent - shiftwidth()
+    let indent = cindent < indent ? cindent : indent - s:sw()
   endif
-  let increase = indent + shiftwidth()
+  let increase = indent + s:sw()
   if indent == indent(lnum)
     let indent = cindent <= indent ? -1 : increase
   endif

--- a/indent/sass.vim
+++ b/indent/sass.vim
@@ -29,9 +29,9 @@ function! GetSassIndent()
   let indent = indent(lnum)
   let cindent = indent(v:lnum)
   if line !~ s:property && line !~ s:extend && cline =~ s:property
-    return indent + &sw
+    return indent + shiftwidth()
   "elseif line =~ s:property && cline !~ s:property
-    "return indent - &sw
+    "return indent - shiftwidth()
   else
     return -1
   endif

--- a/indent/sass.vim
+++ b/indent/sass.vim
@@ -20,6 +20,18 @@ endif
 let s:property = '^\s*:\|^\s*[[:alnum:]#{}-]\+\%(:\|\s*=\)'
 let s:extend = '^\s*\%(@extend\|@include\|+\)'
 
+" The shiftwidth() exists since patch 7.3.694
+" Don't require it to exist.
+if exists('*shiftwidth')
+  function s:sw() abort
+    return shiftwidth()
+  endfunction
+else
+  function s:sw() abort
+    return &shiftwidth
+  endfunction
+endif
+
 function! GetSassIndent()
   let lnum = prevnonblank(v:lnum-1)
   let line = substitute(getline(lnum),'\s\+$','','')
@@ -29,9 +41,9 @@ function! GetSassIndent()
   let indent = indent(lnum)
   let cindent = indent(v:lnum)
   if line !~ s:property && line !~ s:extend && cline =~ s:property
-    return indent + shiftwidth()
+    return indent + s:sw()
   "elseif line =~ s:property && cline !~ s:property
-    "return indent - shiftwidth()
+    "return indent - s:sw()
   else
     return -1
   endif


### PR DESCRIPTION
See https://github.com/vim/vim/pull/578 for details.

> With set shiftwidth=0, gg=G in filetype=vim buffer will result in removing all indents.
> Because indent/vim.vim doesn't use shiftwidth() instead of accessing &sw directly.

This is same as vim-haml.