### PR TITLE
Fix scss comments highlight

### DIFF
--- a/syntax/scss.vim
+++ b/syntax/scss.vim
@@ -10,10 +10,15 @@ endif
 
 runtime! syntax/sass.vim
 
-syn match scssComment "//.*" contains=sassTodo,@Spell
-syn region scssComment start="/\*" end="\*/" contains=sassTodo,@Spell
+syn clear sassComment
+syn clear sassCssComment
+syn clear sassEndOfLineComment
 
-hi def link scssComment sassComment
+syn match scssComment "//.*" contains=sassTodo,@Spell
+syn region scssCssComment start="/\*" end="\*/" contains=sassTodo,@Spell
+
+hi def link scssCssComment scssComment
+hi def link scssComment Comment
 
 let b:current_syntax = "scss"
 


### PR DESCRIPTION
Here are the changes discussed in #78.

BTW I also noticed that `syntax/sass.vim` refers to `scssComment` in some places; `scssComment` previously linked to `sassComment` but now it does not anymore.

Should `sassComment` be added directly to the cluster definitions now?
I don't know these details of vim syntax definitions..