### PR TITLE
Add colon classes to HAML syntax

### DIFF
--- a/syntax/haml.vim
+++ b/syntax/haml.vim
@@ -2,7 +2,7 @@
 " Language:	Haml
 " Maintainer:	Tim Pope <vimNOSPAM@tpope.org>
 " Filenames:	*.haml
-" Last Change:	2016 Aug 29
+" Last Change:	2018 Aug 21
 
 if exists("b:current_syntax")
   finish
@@ -38,7 +38,7 @@ syn match   hamlDespacer "[<>]" contained nextgroup=hamlDespacer,hamlSelfCloser,
 syn match   hamlSelfCloser "/" contained
 syn match   hamlClassChar "\." contained nextgroup=hamlClass
 syn match   hamlIdChar "#{\@!" contained nextgroup=hamlId
-syn match   hamlClass "\%(\w\|-\)\+" contained nextgroup=@hamlComponent
+syn match   hamlClass "\%(\w\|-\|\:\)\+" contained nextgroup=@hamlComponent
 syn match   hamlId    "\%(\w\|-\)\+" contained nextgroup=@hamlComponent
 syn region  hamlDocType start="^\s*!!!" end="$"
 


### PR DESCRIPTION
This adds syntax detection for HAML files.

An example would be if using classes provided by [Tailwind CSS][1]

IE:

```html
<div class="flex sm:inline-flex md:block lg:hidden xl:flex ...">
  <!-- ... -->
</div>
```

```haml
.flex.sm:inline-flex.md:block.lg:hidden.xl:flex
  # ...
```

[1]: https://tailwindcss.com/docs/flexbox-display#responsive