### PR TITLE
Ensure Haml {} attributes end the contained Ruby

### DIFF
--- a/syntax/haml.vim
+++ b/syntax/haml.vim
@@ -2,7 +2,7 @@
 " Language:	Haml
 " Maintainer:	Tim Pope <vimNOSPAM@tpope.org>
 " Filenames:	*.haml
-" Last Change:	2019 Dec 05
+" Last Change:	2023 May 29
 
 if exists("b:current_syntax")
   finish
@@ -32,7 +32,7 @@ syn match   hamlBegin "^\s*\%([<>]\|&[^=~ ]\)\@!" nextgroup=hamlTag,hamlClassCha
 
 syn match   hamlTag        "%\w\+\%(:\w\+\)\=" contained contains=htmlTagName,htmlSpecialTagName nextgroup=@hamlComponent
 syn region  hamlAttributes     matchgroup=hamlAttributesDelimiter start="(" end=")" contained contains=htmlArg,hamlAttributeString,hamlAttributeVariable,htmlEvent,htmlCssDefinition nextgroup=@hamlComponent
-syn region  hamlAttributesHash matchgroup=hamlAttributesDelimiter start="{" end="}" contained contains=@hamlRubyTop nextgroup=@hamlComponent
+syn region  hamlAttributesHash matchgroup=hamlAttributesDelimiter start="{" end="}" skip="{.\{-\}}" contained contains=@hamlRubyTop nextgroup=@hamlComponent keepend
 syn region  hamlObject         matchgroup=hamlObjectDelimiter     start="\[" end="\]" contained contains=@hamlRubyTop nextgroup=@hamlComponent
 syn match   hamlDespacer "[<>]" contained nextgroup=hamlDespacer,hamlSelfCloser,hamlRuby,hamlPlainChar,hamlInterpolatable
 syn match   hamlSelfCloser "/" contained


### PR DESCRIPTION
This fixes an issue with the Haml syntax highlighter where using curly (`{}`) Haml attributes with a nested Ruby hash literal would get the syntax highlighter trapped in Ruby mode for the rest of the file.

E.g.:

```haml
.example{ data: { foo: 'bar' } }
  %p This should be highlighted as Haml

  # This should not be highligted as Ruby!
  class NorShouldThis
    def nope(); end
  end
```

Before my change it looked like this:

<img width="313" alt="Screenshot 2023-05-29 at 7 49 23 PM" src="https://github.com/tpope/vim-haml/assets/38060/70cb1af4-a440-4c6e-88f5-21b1d4be1666">

After my change it looks like this:

<img width="318" alt="Screenshot 2023-05-29 at 7 50 32 PM" src="https://github.com/tpope/vim-haml/assets/38060/8837ab2a-fbe3-4cc2-9a20-0574ed7b4355">

This is my first time working with vim syntax files, so I'm not sure if I missed anything important, but so far this is working perfectly for me.